### PR TITLE
Fix cookie not being parsed on load.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,10 +16,13 @@ function load(name) {
 
 function save(name, val, opt) {
   _cookies[name] = val;
-  
+
   // Cookies only work in the browser
   if (typeof document === 'undefined') return;
   
+  // allow you to work with cookies as objects.
+  if (typeof val === 'object') val = JSON.stringify(val);
+
   document.cookie = cookie.serialize(name, val, opt);
 }
 


### PR DESCRIPTION
If you have to stringify your object before saving, and you add that,
to the `_cookies` cache, then you'll return that on `load` after setting
it with `save`.

While if the value is already set, the script correctly parses the cookie
values and what you load is returned as an object.

This oneliner takes care of that for you.