### PR TITLE
setRawCookie reinitialize bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,9 @@ function remove(name) {
 }
 
 function setRawCookie(rawCookie) {
+  _rawCookies = {};
+  _cookies = {};
+
   if (!rawCookie) {
     return;
   }


### PR DESCRIPTION
When using `setRawCookie` method multiple times you have to reinitialize variables that hold cookies. If `setRawCookie` is called it means that a user wanted to set a new value thus if parameter is `null` or `undefined` it still means that cookie string has changed.

```js
cookie.setRawCookie('token=something');
cookie.load('token') // -> something
cookie.setRawCookie('');
cookie.load('token') // -> something, but should be null
```