### PR TITLE
Fix #18 cookie-parser populates req.cookies (plural)

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,8 @@ function setRawCookie(rawCookie) {
 function plugToRequest(req, res) {
   if (req.cookie) {
     _rawCookie = req.cookie;
+  } else if (req.cookies) {
+    _rawCookie = req.cookies;
   } else if (req.headers && req.headers.cookie) {
     setRawCookie(req.headers.cookie);
   } else {

--- a/test.js
+++ b/test.js
@@ -63,8 +63,13 @@ describe('ReactCookie', function() {
   });
 
   describe('plugToRequest', function() {
-    it('should load the request cookies', function() {
+    it('should load the request cookie', function() {
       reactCookie.plugToRequest({ cookie: { test: 123 } });
+      expect(reactCookie.load('test')).toBe(123);
+    });
+    
+    it('should load the request cookies', function() {
+      reactCookie.plugToRequest({ cookies: { test: 123 } });
       expect(reactCookie.load('test')).toBe(123);
     });
 


### PR DESCRIPTION
This pull request fixes issue #18. It has test coverage and is still backwards compatible.