### PR TITLE
Possibility to load all cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can use react-cookie with anything by using the global variable `reactCookie
 
 ## Usage
 
-### `reactCookie.load(name, [doNotParse])`
+### `reactCookie.load([name], [doNotParse])`
 ### `reactCookie.save(name, val, [opt])`
 ### `reactCookie.remove(name, [opt])`
 ### `reactCookie.plugToRequest(req, res)`

--- a/index.js
+++ b/index.js
@@ -3,15 +3,27 @@ var cookie = require('cookie');
 var _rawCookie = {};
 var _res = undefined;
 
+function parseCookie(cookie) {
+  try {
+    cookie = JSON.parse(cookie);
+  } catch(e) {
+    // Not serialized object
+  }
+  return cookie;
+}
+
 function load(name, doNotParse) {
   var cookies = (typeof document === 'undefined') ? _rawCookie : cookie.parse(document.cookie);
-  var cookieVal = cookies && cookies[name];
+  var cookieVal = name ? cookies[name] : cookies;
 
   if (!doNotParse) {
-    try {
-      cookieVal = JSON.parse(cookieVal);
-    } catch(e) {
-      // Not serialized object
+    if (name) {
+      cookieVal = parseCookie(cookieVal);
+    } else {
+      cookieVal = Object.keys(cookies).reduce(function(result, cookieName) {
+        result[cookieName] = parseCookie(cookies[cookieName]);
+        return result;
+      }, {})
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -18,10 +18,26 @@ describe('ReactCookie', function() {
       reactCookie.setRawCookie('test=test');
       expect(reactCookie.load('test')).toBe('test');
     });
+    
+    it('should load all cookies if name is not provided', function() {
+      reactCookie.setRawCookie('test=test;foo=foo');
+      expect(reactCookie.load()).toEqual({test: 'test', foo: 'foo'});
+    });
+
+    it('should prevent cookies object mutation', function() {
+      reactCookie.setRawCookie('test=test;foo=foo');
+      reactCookie.load().test = 'newValue';
+      expect(reactCookie.load()).toEqual({test: 'test', foo: 'foo'});
+    });
 
     it('should parse if an object', function() {
       reactCookie.setRawCookie('test={"test": true}');
       expect(reactCookie.load('test').test).toBe(true);
+    });
+
+    it('should load all cookies parsed if name is not provided', function() {
+      reactCookie.setRawCookie('test={"test": true};foo=foo');
+      expect(reactCookie.load()).toEqual({test: {test: true}, foo: 'foo'});
     });
 
     it('should not parse if we ask not to', function() {


### PR DESCRIPTION
If 'name' argument is not provided to 'load' method, it should return object with all available cookies