### PR TITLE
Fix for async operations accessing cookie after it has been disposed and Windows builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 Load, save and remove cookies within your React application
 
 ## Isomorphic cookies!
-You can also plug it directly with a Node.js request by adding just before the renderToString: `reactCookie.plugToRequest(req, res);`<br />
+You can also plug it directly with a Node.js request by adding just before the renderToString: `var unplug = reactCookie.plugToRequest(req, res);`<br />
 *(require the cookieParser middleware)*
 
+To ensure long running async operations do not attempt to alter cookies after the request has been sent, call the `unplug` function that is returned in a finally block in your router.
+
 If you are within a non-browser or Node.js environment, you can use `reactCookie.setRawCookie(req.headers.cookie)`
+
+
 
 ## Download
 NPM: `npm install react-cookie`<br />
@@ -51,7 +55,7 @@ You can use react-cookie with anything by using the global variable `reactCookie
 ### `reactCookie.load(name, [doNotParse])`
 ### `reactCookie.save(name, val, [opt])`
 ### `reactCookie.remove(name, [opt])`
-### `reactCookie.plugToRequest(req, res)`
+### `reactCookie.plugToRequest(req, res): unplug()`
 ### `reactCookie.setRawCookie(cookies)`
 
 ## opt

--- a/index.js
+++ b/index.js
@@ -76,6 +76,9 @@ function plugToRequest(req, res) {
   }
 
   _res = res;
+  return function unplug() {
+    _rawCookie = {};
+  }
 }
 
 var reactCookie = {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "browserify": "^9.0.3",
+    "jasmine-core": "^2.4.1",
     "minijasminenode2": "^1.0.0",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "author": "Benoit Tremblay <trembl.ben@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "build": "mkdir -p dist && browserify index.js > dist/react-cookie.js && uglifyjs dist/react-cookie.js -o dist/react-cookie.min.js",
+    "prebuild": "rimraf dist",
+    "build": "mkdirp dist && browserify index.js > dist/react-cookie.js && uglifyjs dist/react-cookie.js -o dist/react-cookie.min.js",
     "test": "node_modules/.bin/minijasminenode2 test.js"
   },
   "dependencies": {
@@ -32,6 +33,8 @@
   "devDependencies": {
     "browserify": "^9.0.3",
     "minijasminenode2": "^1.0.0",
+    "mkdirp": "^0.5.1",
+    "rimraf": "^2.5.2",
     "uglify-js": "^2.4.17"
   }
 }

--- a/test.js
+++ b/test.js
@@ -67,7 +67,7 @@ describe('ReactCookie', function() {
       reactCookie.plugToRequest({ cookie: { test: 123 } });
       expect(reactCookie.load('test')).toBe(123);
     });
-    
+
     it('should load the request cookies', function() {
       reactCookie.plugToRequest({ cookies: { test: 123 } });
       expect(reactCookie.load('test')).toBe(123);
@@ -85,5 +85,19 @@ describe('ReactCookie', function() {
       reactCookie.plugToRequest({});
       expect(reactCookie.load('test')).toBeUndefined();
     });
+
+    describe('unplug', function () {
+      it('should return an unplug function', function() {
+        var unplug = reactCookie.plugToRequest({ headers: { cookie: 'test=123' } });
+        expect(typeof unplug).toBe('function')
+      })
+
+      it('should clear reference to request cookie when called', function() {
+        var unplug = reactCookie.plugToRequest({ headers: { cookie: 'test=123' } });
+        expect(reactCookie.load('test')).toBe(123);
+        unplug()
+        expect(reactCookie.load('test')).toBeUndefined();
+      })
+    })
   });
 });


### PR DESCRIPTION
I've been using this library for a while and love it, just recently I added universal rendering and have been noticing an intermittent issue with react-cookie attempting to write cookies after the request has been sent from express. I believe its due to async things getting run and resolving after the res.send().

Since plugToRequest has no return type now, I altered it to return a thunk that will effectively dispose of any operations on the current request. I realize I could setRawCookie({}) at the end of the request, but returning a disposer infers to the user that they are doing an operation that should be disposed and is simpler to use.

When I tried to build it, I got some issues, `mkdir -p` creates a `-p` folder on windows and everything else blows up. I fixed this by adding dev dependency `mkdirp`. While I was at it I added dev dependency `rimraf` and made it clean up the dist prior to build.

When I tried to run test, that also failed saying it couldn't find `jasmine-core` so I added that also.

Thoughts?