### PR TITLE
select regex cookie selector and Object.assign polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ import cookie from 'react-cookie';
 export default class MyApp extends Component {
   constructor(props) {
     super(props);
-    this.state = { userId: cookie.load('userId') };
+
+    this.state =  { userId: cookie.load('userId')
+                  , sessionCookies: cookie.select(/^session.*/i)
+                  };
   }
 
   onLogin(userId) {
@@ -35,6 +38,7 @@ export default class MyApp extends Component {
 
   onLogout() {
     cookie.remove('userId', { path: '/' });
+    Object.keys(this.state.sessionCookies).forEach(name => cookie.remove(name, { path: '/' }))
   }
 
   render() {
@@ -53,6 +57,7 @@ You can use react-cookie with anything by using the global variable `reactCookie
 ## Usage
 
 ### `reactCookie.load(name, [doNotParse])`
+### `reactCookie.select(/regex/)`
 ### `reactCookie.save(name, val, [opt])`
 ### `reactCookie.remove(name, [opt])`
 ### `reactCookie.plugToRequest(req, res): unplug()`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ export default class MyApp extends Component {
     super(props);
 
     this.state =  { userId: cookie.load('userId')
-                  , sessionCookies: cookie.select(/^session.*/i)
                   };
   }
 
@@ -38,7 +37,9 @@ export default class MyApp extends Component {
 
   onLogout() {
     cookie.remove('userId', { path: '/' });
-    Object.keys(this.state.sessionCookies).forEach(name => cookie.remove(name, { path: '/' }))
+
+    /** Clear all cookies starting with 'session' (to get all cookies, omit regex argument) */
+    Object.keys(cookie.select(/^session.*/i)).forEach(name => cookie.remove(name, { path: '/' }))
   }
 
   render() {
@@ -57,7 +58,7 @@ You can use react-cookie with anything by using the global variable `reactCookie
 ## Usage
 
 ### `reactCookie.load(name, [doNotParse])`
-### `reactCookie.select(/regex/)`
+### `reactCookie.select([regex])`
 ### `reactCookie.save(name, val, [opt])`
 ### `reactCookie.remove(name, [opt])`
 ### `reactCookie.plugToRequest(req, res): unplug()`

--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 Load, save and remove cookies within your React application
 
 ## Isomorphic cookies!
-You can also plug it directly with a Node.js request by adding just before the renderToString: `reactCookie.plugToRequest(req, res);`<br />
+You can also plug it directly with a Node.js request by adding just before the renderToString: `var unplug = reactCookie.plugToRequest(req, res);`<br />
 *(require the cookieParser middleware)*
 
+To ensure long running async operations do not attempt to alter cookies after the request has been sent, call the `unplug` function that is returned in a finally block in your router.
+
 If you are within a non-browser or Node.js environment, you can use `reactCookie.setRawCookie(req.headers.cookie)`
+
+
 
 ## Download
 NPM: `npm install react-cookie`<br />
@@ -51,7 +55,7 @@ You can use react-cookie with anything by using the global variable `reactCookie
 ### `reactCookie.load(name, [doNotParse])`
 ### `reactCookie.save(name, val, [opt])`
 ### `reactCookie.remove(name, [opt])`
-### `reactCookie.plugToRequest(req, res)`
+### `reactCookie.plugToRequest(req, res): unplug()`
 ### `reactCookie.setRawCookie(cookies)`
 
 ## opt

--- a/index.js
+++ b/index.js
@@ -44,11 +44,10 @@ function load(name, doNotParse) {
 function select(regex) {
   var cookies = (typeof document === 'undefined') ? _rawCookie : cookie.parse(document.cookie);
   if(!cookies)
-    return []
-  console.info(cookies)
+    return {}
   return Object.keys(cookies)
     .reduce(function(accumulator, name) {
-      if(!regex.test(name))
+      if(regex && !regex.test(name))
         return accumulator
       var newCookie = {}
       newCookie[name] = cookies[name]

--- a/index.js
+++ b/index.js
@@ -3,6 +3,29 @@ var cookie = require('cookie');
 var _rawCookie = {};
 var _res = undefined;
 
+if (typeof Object.assign != 'function') {
+  Object.assign = function(target) {
+    'use strict';
+    if (target == null) {
+      throw new TypeError('Cannot convert undefined or null to object');
+    }
+
+    target = Object(target);
+    for (var index = 1; index < arguments.length; index++) {
+      var source = arguments[index];
+      if (source != null) {
+        for (var key in source) {
+          if (Object.prototype.hasOwnProperty.call(source, key)) {
+            target[key] = source[key];
+          }
+        }
+      }
+    }
+    return target;
+  };
+}
+
+
 function load(name, doNotParse) {
   var cookies = (typeof document === 'undefined') ? _rawCookie : cookie.parse(document.cookie);
   var cookieVal = cookies && cookies[name];
@@ -16,6 +39,21 @@ function load(name, doNotParse) {
   }
 
   return cookieVal;
+}
+
+function select(regex) {
+  var cookies = (typeof document === 'undefined') ? _rawCookie : cookie.parse(document.cookie);
+  if(!cookies)
+    return []
+  console.info(cookies)
+  return Object.keys(cookies)
+    .reduce(function(accumulator, name) {
+      if(!regex.test(name))
+        return accumulator
+      var newCookie = {}
+      newCookie[name] = cookies[name]
+      return Object.assign({}, accumulator, newCookie)
+    }, {})
 }
 
 function save(name, val, opt) {
@@ -83,6 +121,7 @@ function plugToRequest(req, res) {
 
 var reactCookie = {
   load: load,
+  select: select,
   save: save,
   remove: remove,
   setRawCookie: setRawCookie,

--- a/index.js
+++ b/index.js
@@ -52,9 +52,11 @@ function select(regex) {
   var cookies = (typeof document === 'undefined') ? _rawCookie : cookie.parse(document.cookie);
   if(!cookies)
     return {}
+  if(!regex)
+    return cookies
   return Object.keys(cookies)
     .reduce(function(accumulator, name) {
-      if(regex && !regex.test(name))
+      if(!regex.test(name))
         return accumulator
       var newCookie = {}
       newCookie[name] = cookies[name]

--- a/index.js
+++ b/index.js
@@ -76,6 +76,9 @@ function plugToRequest(req, res) {
   }
 
   _res = res;
+  return function unplug() {
+    _rawCookie = {};
+  }
 }
 
 var reactCookie = {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,5 @@
 var cookie = require('cookie');
 
-var _rawCookie = {};
-var _res = undefined;
-
 if (typeof Object.assign != 'function') {
   Object.assign = function(target) {
     'use strict';
@@ -25,6 +22,16 @@ if (typeof Object.assign != 'function') {
   };
 }
 
+var _rawCookie = {};
+var _res = undefined;
+
+function _isResWritable() {
+  if(!_res)
+    return false
+  if(_res.headersSent === true)
+    return false
+  return true
+}
 
 function load(name, doNotParse) {
   var cookies = (typeof document === 'undefined') ? _rawCookie : cookie.parse(document.cookie);
@@ -68,7 +75,7 @@ function save(name, val, opt) {
     document.cookie = cookie.serialize(name, _rawCookie[name], opt);
   }
 
-  if (_res && _res.cookie) {
+  if (_isResWritable() && _res.cookie) {
     _res.cookie(name, val, opt);
   }
 }
@@ -88,7 +95,7 @@ function remove(name, opt) {
     document.cookie = cookie.serialize(name, '', opt);
   }
 
-  if (_res && _res.clearCookie) {
+  if (_isResWritable() && _res.clearCookie) {
     _res.clearCookie(name, opt);
   }
 }
@@ -114,6 +121,7 @@ function plugToRequest(req, res) {
 
   _res = res;
   return function unplug() {
+    _res = null;
     _rawCookie = {};
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "browserify": "^9.0.3",
+    "jasmine-core": "^2.4.1",
     "minijasminenode2": "^1.0.0",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "author": "Benoit Tremblay <trembl.ben@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "build": "mkdir -p dist && browserify index.js > dist/react-cookie.js && uglifyjs dist/react-cookie.js -o dist/react-cookie.min.js",
+    "prebuild": "rimraf dist",
+    "build": "mkdirp dist && browserify index.js > dist/react-cookie.js && uglifyjs dist/react-cookie.js -o dist/react-cookie.min.js",
     "test": "node_modules/.bin/minijasminenode2 test.js"
   },
   "dependencies": {
@@ -32,6 +33,8 @@
   "devDependencies": {
     "browserify": "^9.0.3",
     "minijasminenode2": "^1.0.0",
+    "mkdirp": "^0.5.1",
+    "rimraf": "^2.5.2",
     "uglify-js": "^2.4.17"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jasmine-core": "^2.4.1",
     "minijasminenode2": "^1.0.0",
     "mkdirp": "^0.5.1",
+    "rewire": "^2.5.1",
     "rimraf": "^2.5.2",
     "uglify-js": "^2.4.17"
   }

--- a/test.js
+++ b/test.js
@@ -30,6 +30,21 @@ describe('ReactCookie', function() {
     });
   });
 
+  describe('select', function() {
+    it('should not crash if cookies undefined', function() {
+      expect(function() {
+        reactCookie.setRawCookie(undefined);
+      }).not.toThrow();
+
+      expect(reactCookie.select(/^test/g)).toEqual({});
+    });
+
+    it('should select and read all the matching cookies into an object', function() {
+      reactCookie.setRawCookie('test=foo;something=bar;foo=bar');
+      expect(reactCookie.select(/(test|foo)/)).toEqual({ test: 'foo', foo: 'bar' });
+    });
+  })
+
   describe('save', function() {
     it('should not crash if not in the browser', function() {
       expect(function() {

--- a/test.js
+++ b/test.js
@@ -43,6 +43,11 @@ describe('ReactCookie', function() {
       reactCookie.setRawCookie('test=foo;something=bar;foo=bar');
       expect(reactCookie.select(/(test|foo)/)).toEqual({ test: 'foo', foo: 'bar' });
     });
+
+    it('should read all cookies into an object if no parameter is passed', function() {
+      reactCookie.setRawCookie('test=foo;something=bar;foo=bar');
+      expect(reactCookie.select()).toEqual({ test: 'foo', something: 'bar', foo: 'bar' });
+    });
   })
 
   describe('save', function() {

--- a/test.js
+++ b/test.js
@@ -67,7 +67,7 @@ describe('ReactCookie', function() {
       reactCookie.plugToRequest({ cookie: { test: 123 } });
       expect(reactCookie.load('test')).toBe(123);
     });
-    
+
     it('should load the request cookies', function() {
       reactCookie.plugToRequest({ cookies: { test: 123 } });
       expect(reactCookie.load('test')).toBe(123);
@@ -85,5 +85,19 @@ describe('ReactCookie', function() {
       reactCookie.plugToRequest({});
       expect(reactCookie.load('test')).toBeUndefined();
     });
+
+    describe('unplug', function () {
+      it('should return an unplug function', function() {
+        var unplug = reactCookie.plugToRequest({ headers: { cookie: 'test=123' } });
+        expect(typeof unplug).toBe('function')
+      })
+
+      it('should clear reference to request cookie when called', function() {
+        var unplug = reactCookie.plugToRequest({ headers: { cookie: 'test=123' } });
+        expect(reactCookie.load('test')).toBe(123);
+        unplug()
+        expect(reactCookie.load('test')).toBeUndefined();
+      })
+    })
   });
 });


### PR DESCRIPTION
This has all the items from https://github.com/eXon/react-cookie/pull/25 with an additional select function to match multiple cookies. I included an inline Object.assign polyfill so should be good to at least IE9 with no other shims.

All tests are passing. Let me know what you think.