### PR TITLE
Prevent mutation of opt in remove

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,9 @@ function remove(name, opt) {
   } else if (typeof opt === 'string') {
     // Will be deprecated in future versions
     opt = { path: opt };
+  } else {
+    // Prevent mutation of opt below
+    opt = Object.assign({}, opt);
   }
 
   if (typeof document !== 'undefined') {


### PR DESCRIPTION
`expires` is being set on the passed `opt` object in `cookie.remove()`, disallowing the use of a variable for default opts. 

e.g.
```javascript
import cookie from 'react-cookie';

const opt = {
    path : '/'
};

cookie.save('key', 'value', opt);
cookie.remove('key', opt);

console.log(opt); // {path: "/", expires: ...}

// Not saved because expires is set to 1970
cookie.save('key', 'newvalue', opt);
```