### PR TITLE
Override maxAge like expires to force cookie removal

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ function remove(name, opt) {
 
   if (typeof document !== 'undefined') {
     opt.expires = new Date(1970, 1, 1, 0, 0, 1);
+    opt.maxAge = 0;
     document.cookie = cookie.serialize(name, '', opt);
   }
 


### PR DESCRIPTION
Hi,

Thanks for this package.

As the title say, for the sake of consistency, if we override the `expires` to set a date in the past that would trigger the cookie removal, we should do the same with `maxAge`.
That prevent cookies existing with contradictory information: `expires` in the past but `maxAge` in the future.
